### PR TITLE
fix(config): restore missing theme configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,10 @@ copyright: Copyright &copy; 2023-2025 IntelliStream Lab
 
 theme:
   name: material
-  language: en
+  language: zh
+  custom_dir: theme
+  favicon: assets/img/isage_light.svg
+  logo: assets/logo/sage.svg
   palette:
   - scheme: default
     primary: indigo


### PR DESCRIPTION
Problem:
- Landing page was broken after merge
- custom_dir, favicon, and logo configurations were lost in merge
- Theme assets in theme/ directory were not being used

Solution:
- Restore custom_dir: theme
- Restore favicon and logo paths
- Change language back to zh (Chinese)

This fixes the broken landing page at https://intellistream.github.io/SAGE-Pub/