### PR TITLE
Link vLLM-HUST ecosystem card to the official website

### DIFF
--- a/theme/index.html
+++ b/theme/index.html
@@ -147,7 +147,7 @@
         <a href="https://lab.sage.org.ai/"><span>00</span><strong>IntelliStream</strong><small>Cross-layer research incubator</small></a>
         <a class="active" href="#top"><span>01</span><strong>SAGE</strong><small>Applications, agents, RAG, workflows</small></a>
         <a href="https://datasys.sage.org.ai/"><span>02</span><strong>DataSys</strong><small>Streams, graphs, vectors, indexes</small></a>
-        <a href="https://github.com/vllm-hust"><span>03</span><strong>vLLM-HUST</strong><small>Runtime, scheduling, kernels, hardware</small></a>
+        <a href="https://vllm-hust.sage.org.ai/"><span>03</span><strong>vLLM-HUST</strong><small>Runtime, scheduling, kernels, hardware</small></a>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary

Point the vLLM-HUST card in the shared architecture strip to https://vllm-hust.sage.org.ai/ instead of the GitHub organization page.

## Validation

- git diff --check