### PR TITLE
feat: add ICPP 2026 achievements

### DIFF
--- a/docs_src/achievements.md
+++ b/docs_src/achievements.md
@@ -1,0 +1,27 @@
+---
+title: 成果
+hide:
+  - toc
+---
+
+# 成果
+
+这里记录 SAGE 在应用、Agent、RAG、工作流与服务编排方向的论文、系统演示和可复现实验成果。录用成果与正式出版条目分开标注。
+
+## 2026
+
+!!! success "ICPP 2026 Demo · Accepted"
+
+    **Demonstrating SAGE: A Dataflow-Native Framework for Modular, Controllable, and Transparent LLM-Augmented Reasoning**
+
+    **Authors:** Jun Liu and Shuhao Zhang  
+    **Venue:** International Conference on Parallel Processing (ICPP 2026), Demo Track  
+    **Status:** Accepted demonstration
+
+    The demonstration presents SAGE as a dataflow-native application and orchestration framework for composing modular, controllable, and transparent LLM-augmented reasoning pipelines.
+
+    [SAGE core repository](https://github.com/SAGE-Research/SAGE){ .md-button }
+
+!!! info "System boundary"
+
+    This page records the SAGE orchestration demonstration. The separately accepted BriskSnapshot demonstration and its BriskFlow data-system core are maintained by [DataSys](https://datasys.sage.org.ai/achievements.html).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ theme:
 
 nav:
   - 首页: index.md
+  - 成果: achievements.md
   - 关于: about.md
   - 入门: getting-started/index.md
   - 教程:

--- a/theme/index.html
+++ b/theme/index.html
@@ -20,6 +20,7 @@
     </a>
     <nav aria-label="Primary navigation">
       <a href="#platform">Platform</a>
+      <a href="{{ '/achievements/' | url }}">Achievements</a>
       <a href="#directory">Repository atlas</a>
       <a href="{{ '/getting-started/installation/' | url }}">Docs</a>
       <a class="nav-action" href="https://github.com/SAGE-Research">GitHub <span aria-hidden="true">↗</span></a>
@@ -41,7 +42,7 @@
         </div>
       </div>
       <dl class="hero-metrics" aria-label="Organization overview">
-        <div><dt>25</dt><dd>public projects</dd></div>
+        <div><dt>24</dt><dd>public projects</dd></div>
         <div><dt>05</dt><dd>capability groups</dd></div>
         <div><dt>L1–L5</dt><dd>learning path</dd></div>
       </dl>
@@ -86,7 +87,7 @@
         <p>The directory separates framework surfaces, reusable libraries, evaluation assets, and developer tools.</p>
       </div>
       <div class="filterbar" role="group" aria-label="Filter repositories">
-        <button class="filter active" type="button" data-filter="all" aria-pressed="true">All <span>25</span></button>
+        <button class="filter active" type="button" data-filter="all" aria-pressed="true">All <span>24</span></button>
         <button class="filter" type="button" data-filter="platform" aria-pressed="false">Platform</button>
         <button class="filter" type="button" data-filter="agent" aria-pressed="false">Agent</button>
         <button class="filter" type="button" data-filter="rag" aria-pressed="false">RAG + Memory</button>
@@ -115,7 +116,6 @@
         <a class="repo-row" data-categories="rag evaluation" href="https://github.com/SAGE-Research/sage-rag-benchmark"><span class="repo-name">sage-rag-benchmark</span><span class="repo-role">Retrieval workflow evaluation</span><span class="tag tag-amber">benchmark</span><span class="arrow">↗</span></a>
         <a class="repo-row" data-categories="rag evaluation" href="https://github.com/SAGE-Research/sage-refiner-benchmark"><span class="repo-name">sage-refiner-benchmark</span><span class="repo-role">Refinement component evaluation</span><span class="tag tag-amber">benchmark</span><span class="arrow">↗</span></a>
         <a class="repo-row" data-categories="rag learning" href="https://github.com/SAGE-Research/sage-wiki"><span class="repo-name">sage-wiki</span><span class="repo-role">Knowledge and ecosystem wiki</span><span class="tag tag-cyan">knowledge</span><span class="arrow">↗</span></a>
-        <a class="repo-row" data-categories="platform tools" href="https://github.com/SAGE-Research/sageFlow"><span class="repo-name">sageFlow</span><span class="repo-role">Workflow composition surface</span><span class="tag tag-green">framework</span><span class="arrow">↗</span></a>
         <a class="repo-row" data-categories="rag" href="https://github.com/SAGE-Research/sageRefiner"><span class="repo-name">sageRefiner</span><span class="repo-role">Retrieval result refinement</span><span class="tag tag-green">library</span><span class="arrow">↗</span></a>
         <a class="repo-row" data-categories="tools" href="https://github.com/SAGE-Research/sagepypi"><span class="repo-name">sagepypi</span><span class="repo-role">Monorepo package compiler and publisher</span><span class="tag tag-coral">tooling</span><span class="arrow">↗</span></a>
         <a class="repo-row" data-categories="rag" href="https://github.com/SAGE-Research/wiki-link-retrieval"><span class="repo-name">wiki-link-retrieval</span><span class="repo-role">Curated link-graph expansion</span><span class="tag">research</span><span class="arrow">↗</span></a>


### PR DESCRIPTION
Publishes the accepted SAGE ICPP 2026 demo on a new achievements page, removes the transferred sageFlow entry from the SAGE project directory, and points DataSys-owned BriskFlow work to its canonical repository. Validation: 2 tests passed, Zensical build completed without issues, and desktop/mobile browser QA showed no overflow or console errors.