### PR TITLE
fix: restore mobile achievements navigation

### DIFF
--- a/theme/achievements.css
+++ b/theme/achievements.css
@@ -27,6 +27,10 @@
   border-color: var(--accent);
 }
 
+.mobile-nav {
+  display: none;
+}
+
 .publication-hero {
   position: relative;
   min-height: 590px;
@@ -260,9 +264,44 @@
     display: none;
   }
 
+  .mobile-nav {
+    position: absolute;
+    z-index: 19;
+    top: 64px;
+    left: 0;
+    right: 0;
+    min-height: 48px;
+    padding: 0 max(4vw, 16px);
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    color: #aebdbc;
+    background: rgba(7, 11, 12, .94);
+    border-bottom: 1px solid rgba(255, 255, 255, .18);
+    backdrop-filter: blur(14px);
+  }
+
+  .mobile-nav a {
+    min-height: 48px;
+    display: grid;
+    place-items: center;
+    color: inherit;
+    border-bottom: 2px solid transparent;
+    font-size: 12px;
+    font-weight: 800;
+    text-decoration: none;
+    white-space: nowrap;
+  }
+
+  .mobile-nav a:hover,
+  .mobile-nav a:focus-visible,
+  .mobile-nav .active {
+    color: var(--white);
+    border-bottom-color: var(--accent);
+  }
+
   .publication-hero {
     min-height: 590px;
-    padding-top: 120px;
+    padding-top: 168px;
     padding-bottom: 54px;
   }
 

--- a/theme/achievements.html
+++ b/theme/achievements.html
@@ -28,6 +28,12 @@
       <a class="nav-action" href="https://github.com/SAGE-Research">GitHub <span aria-hidden="true">↗</span></a>
     </nav>
   </header>
+  <nav class="mobile-nav" aria-label="Mobile navigation">
+    <a href="{{ '/' | url }}" data-en="Home" data-zh="首页">首页</a>
+    <a class="active" href="{{ '/achievements/' | url }}" data-en="Publications" data-zh="成果">成果</a>
+    <a href="{{ '/getting-started/installation/' | url }}" data-en="Docs" data-zh="文档">文档</a>
+    <a href="https://github.com/SAGE-Research">GitHub <span aria-hidden="true">↗</span></a>
+  </nav>
 
   <main id="top">
     <section class="publication-hero" aria-labelledby="page-title">


### PR DESCRIPTION
Add an always-visible four-item mobile navigation rail for Home, Publications, Docs, and GitHub. Verified at 320px and 390px with 48px targets and no overflow.