### PR TITLE
fix: keep mobile external link inline

### DIFF
--- a/theme/achievements.css
+++ b/theme/achievements.css
@@ -282,8 +282,10 @@
 
   .mobile-nav a {
     min-height: 48px;
-    display: grid;
-    place-items: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
     color: inherit;
     border-bottom: 2px solid transparent;
     font-size: 12px;


### PR DESCRIPTION
Keep the GitHub label and external-link arrow on one line in the mobile achievements navigation.