### PR TITLE
docs: qualify ICPP demo acceptance evidence

### DIFF
--- a/theme/achievements.html
+++ b/theme/achievements.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="SAGE formally accepted and published work in agent, RAG, workflow, memory, and application orchestration.">
+  <meta name="description" content="SAGE publications and author-reported accepted demonstrations in agent, RAG, workflow, memory, and application orchestration.">
   <meta property="og:url" content="https://sage.org.ai/achievements/">
   <meta property="og:image" content="https://sage.org.ai/assets/img/ecosystem-infrastructure.png">
   <link rel="canonical" href="https://sage.org.ai/achievements/">
@@ -42,15 +42,15 @@
       <div class="publication-hero-copy">
         <p class="signal"><span></span><span data-en="SAGE / PUBLICATION LINE / 2026" data-zh="SAGE / 成果发布线 / 2026">SAGE / 成果发布线 / 2026</span></p>
         <h1 id="page-title" data-en="SAGE Publications" data-zh="SAGE 发表成果">SAGE 发表成果</h1>
-        <p class="publication-hero-summary" data-en="Formally accepted and published work in agent, RAG, workflow, memory, and application orchestration." data-zh="SAGE 在 Agent、RAG、工作流、记忆与应用编排方向正式接收和发表的成果。">SAGE 在 Agent、RAG、工作流、记忆与应用编排方向正式接收和发表的成果。</p>
+        <p class="publication-hero-summary" data-en="Published work and clearly labeled author-reported acceptances in agent, RAG, workflow, memory, and application orchestration." data-zh="SAGE 在 Agent、RAG、工作流、记忆与应用编排方向的已发表成果，以及明确标注的作者报告接收成果。">SAGE 在 Agent、RAG、工作流、记忆与应用编排方向的已发表成果，以及明确标注的作者报告接收成果。</p>
       </div>
     </section>
 
     <section class="publication-rail" aria-label="Publication overview">
       <div><span>01</span><strong>2026</strong><small data-en="release year" data-zh="发布年份">发布年份</small></div>
-      <div><span>02</span><strong>04</strong><small data-en="formal results" data-zh="正式成果">正式成果</small></div>
+      <div><span>02</span><strong>04</strong><small data-en="listed outputs" data-zh="收录成果">收录成果</small></div>
       <div><span>03</span><strong>03</strong><small data-en="research venues" data-zh="学术会议">学术会议</small></div>
-      <div><span>04</span><strong data-en="FORMAL" data-zh="正式">正式</strong><small data-en="publication policy" data-zh="收录口径">收录口径</small></div>
+      <div><span>04</span><strong data-en="EVIDENCE" data-zh="证据">证据</strong><small data-en="publication policy" data-zh="收录口径">收录口径</small></div>
     </section>
 
     <section class="publication-intro">
@@ -58,14 +58,14 @@
         <p class="eyebrow" data-en="Publication policy" data-zh="成果收录政策">成果收录政策</p>
         <h2 data-en="Published work, without the noise." data-zh="只展示已经确认的成果。">只展示已经确认的成果。</h2>
       </div>
-      <p data-en="Only formally accepted or published work appears here. Incubating projects and submission-stage manuscripts are excluded." data-zh="本页只展示已正式接收或发表的成果；孵化中项目和投稿阶段稿件不列入成果。">本页只展示已正式接收或发表的成果；孵化中项目和投稿阶段稿件不列入成果。</p>
+      <p data-en="Published work is linked to public records. Author-reported acceptances remain explicitly labeled until the conference program or proceedings becomes public; submission-stage manuscripts are excluded." data-zh="已发表成果链接公开记录；作者报告的接收成果在会议日程或论文集公开前会明确标注，投稿阶段稿件不列入成果。">已发表成果链接公开记录；作者报告的接收成果在会议日程或论文集公开前会明确标注，投稿阶段稿件不列入成果。</p>
     </section>
 
     <section class="publication-section" aria-labelledby="year-2026">
       <div class="publication-year">
         <p class="eyebrow">PUBLICATION LINE</p>
         <h2 id="year-2026">2026</h2>
-        <p data-en="Accepted and published work" data-zh="正式发表与接收成果">正式发表与接收成果</p>
+        <p data-en="Published work and labeled acceptance reports" data-zh="已发表成果与明确标注的接收报告">已发表成果与明确标注的接收报告</p>
       </div>
 
       <div class="publication-list">
@@ -108,8 +108,9 @@
             <p class="publication-authors">Jun Liu, Shuhao Zhang</p>
             <p data-en="A live demonstration of modular reasoning pipelines, inspectable dataflow execution, and application-level control in SAGE." data-zh="现场演示 SAGE 中模块化推理 Pipeline、可检查的数据流执行与应用层控制能力。">现场演示 SAGE 中模块化推理 Pipeline、可检查的数据流执行与应用层控制能力。</p>
             <a class="publication-link" href="https://github.com/SAGE-Research/SAGE" data-en="SAGE core repository ↗" data-zh="SAGE 核心仓库 ↗">SAGE 核心仓库 ↗</a>
+            <p data-en="Acceptance is reported by the authors; the public ICPP 2026 program or proceedings record is pending." data-zh="接收状态由作者报告；ICPP 2026 公开日程或论文集记录尚待发布。">接收状态由作者报告；ICPP 2026 公开日程或论文集记录尚待发布。</p>
           </div>
-          <span class="tag tag-coral" data-en="Accepted demo" data-zh="已接收演示">已接收演示</span>
+          <span class="tag tag-coral" data-en="Author-reported acceptance" data-zh="作者报告已接收">作者报告已接收</span>
         </article>
       </div>
     </section>


### PR DESCRIPTION
Aligns the SAGE achievements evidence policy with the DataSys page: the ICPP 2026 demo remains listed as an author-reported acceptance while the public program/proceedings record is pending.