### PR TITLE
docs: link primary publication records

### DIFF
--- a/theme/achievements.html
+++ b/theme/achievements.html
@@ -75,6 +75,7 @@
             <h3>SAGE: A Dataflow-Native Framework for Modular, Controllable, and Transparent LLM-Augmented Reasoning</h3>
             <p class="publication-authors">Jun Liu, Peilin Liu, Ruicheng Zhang, Senlei Zhang, Yanbo Chen, Ziao Wang, Jinyun Yang, Mingqi Wang, Shuhao Zhang, Xiaofei Liao, Hai Jin</p>
             <p data-en="A dataflow-native framework for composing modular, controllable, and transparent LLM-augmented reasoning systems." data-zh="面向模块化、可控和透明大模型增强推理系统的数据流原生框架。">面向模块化、可控和透明大模型增强推理系统的数据流原生框架。</p>
+            <a class="publication-link" href="https://openreview.net/forum?id=TXcFJdT7at" data-en="ICML / OpenReview ↗" data-zh="ICML / OpenReview ↗">ICML / OpenReview ↗</a>
             <a class="publication-link" href="https://github.com/SAGE-Research/SAGE" data-en="SAGE core repository ↗" data-zh="SAGE 核心仓库 ↗">SAGE 核心仓库 ↗</a>
           </div>
           <span class="tag tag-green" data-en="Published" data-zh="已发表">已发表</span>
@@ -86,6 +87,8 @@
             <h3>Neuromem: A Granular Decomposition of the Streaming Lifecycle in External Memory for LLMs</h3>
             <p class="publication-authors">Ruicheng Zhang, Xinyi Li, Tianyi Xu, Shuhao Zhang, Xiaofei Liao, Hai Jin</p>
             <p data-en="A granular decomposition of how external memory is written, maintained, retrieved, and consumed across long-running LLM applications." data-zh="细粒度分解长时运行大模型应用中外部记忆的写入、维护、检索与消费生命周期。">细粒度分解长时运行大模型应用中外部记忆的写入、维护、检索与消费生命周期。</p>
+            <a class="publication-link" href="https://openreview.net/forum?id=mO7DgwFFVe" data-en="ICML / OpenReview ↗" data-zh="ICML / OpenReview ↗">ICML / OpenReview ↗</a>
+            <a class="publication-link" href="https://arxiv.org/abs/2602.13967" data-en="arXiv ↗" data-zh="arXiv ↗">arXiv ↗</a>
             <a class="publication-link" href="https://github.com/SAGE-Research/neuromem-bench" data-en="Public benchmark ↗" data-zh="公开评测仓库 ↗">公开评测仓库 ↗</a>
           </div>
           <span class="tag tag-cyan" data-en="Published" data-zh="已发表">已发表</span>
@@ -97,6 +100,8 @@
             <h3>FlowRAG: Continual Learning for Dynamic Retriever in Retrieval-Augmented Generation</h3>
             <p class="publication-authors">Senlei Zhang, Tongjun Shi, Dandan Song, Luan Zhang, Shuhao Zhang, Xiaofei Liao, Hai Jin</p>
             <p data-en="Continual retriever adaptation for evolving corpora using lightweight prompt updates and generator-guided alignment." data-zh="面向持续演化语料库，通过轻量提示更新与生成器引导对齐实现检索器持续适应。">面向持续演化语料库，通过轻量提示更新与生成器引导对齐实现检索器持续适应。</p>
+            <a class="publication-link" href="https://doi.org/10.1145/3774904.3792361" data-en="Paper / DOI ↗" data-zh="论文 / DOI ↗">论文 / DOI ↗</a>
+            <a class="publication-link" href="https://github.com/CGCL-codes/FlowRAG" data-en="Canonical code repository ↗" data-zh="论文代码仓库 ↗">论文代码仓库 ↗</a>
           </div>
           <span class="tag tag-amber" data-en="Published" data-zh="已发表">已发表</span>
         </article>


### PR DESCRIPTION
Cross-checks the personal publication list against the project README and organization publication pages. Adds primary DOI/OpenReview evidence, corrects authorship and canonical links, and keeps author-reported acceptances explicitly qualified.